### PR TITLE
updated input.user.key -> input.user.id

### DIFF
--- a/content/src/policies/__id/post.rego
+++ b/content/src/policies/__id/post.rego
@@ -24,7 +24,7 @@ allowed {
 
 # Check the Aserto Directory to see if the user is a manager or in the management chain
 allowed {
-	directory.is_manager_of(input.user.key, input.resource.id)
+	directory.is_manager_of(input.user.id, input.resource.id)
 }
 
 # Enabled is set to the result of the Allowed decision

--- a/content/src/policies/__id/put.rego
+++ b/content/src/policies/__id/put.rego
@@ -25,6 +25,6 @@ allowed {
 
 # Check if the logged-in user is the same as the employee being updated
 allowed {
-	input.user.key == input.resource.id
+	input.user.id == input.resource.id
 }
 


### PR DESCRIPTION
Changing the policy to use the `id` field instead of `key` field, which is going away at some point.
