### PR TITLE
Update CI to push all image tags in one call

### DIFF
--- a/.github/workflows/publish-template.yaml
+++ b/.github/workflows/publish-template.yaml
@@ -65,12 +65,10 @@ jobs:
         REPO:   ${{ steps.template-config.outputs.repo }}
         SERVER: ${{ steps.template-config.outputs.server }}
       run: |
-       while read -r tag; do
-          oras push "${SERVER}/${REPO}:${tag}" \
+        oras push "${SERVER}/${REPO}:${{ join(steps.meta.outputs.tags, ',') }}" \
           --annotation-file ./annotations.json \
           --config ./config.json \
           --artifact-type application/vnd.oci.image.layer.v1.tar+gzip ./bundle.tar.gz
-        done < <(echo "${{ steps.meta.outputs.tags }}")
 
     - name: Oras Logout
       id: "oras-logout"


### PR DESCRIPTION
The [CI failed](https://github.com/aserto-templates/policy-peoplefinder-rebac/actions/runs/8808214284/job/24225810463) on the latest tag with:
```
while read -r tag; do
     oras push "${SERVER}/${REPO}:${tag}" \
     --annotation-file ./annotations.json \
     --config ./config.json \
     --artifact-type application/vnd.oci.image.layer.v1.tar+gzip ./bundle.tar.gz
   done < <(echo "ghcr.io/aserto-templates/policy-peoplefinder-rebac:2.3.0
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:2.3
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:2
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:sha-f1d9163
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:latest")
  shell: /usr/bin/bash -e {0}
  env:
    DOCKER_METADATA_OUTPUT_VERSION: 2.3.0
    DOCKER_METADATA_OUTPUT_TAGS: ghcr.io/aserto-templates/policy-peoplefinder-rebac:2.3.0
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:2.3
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:2
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:sha-f1d9163
  ghcr.io/aserto-templates/policy-peoplefinder-rebac:latest
    DOCKER_METADATA_OUTPUT_LABELS: org.opencontainers.image.created=2024-04-24T22:21:24.540Z
  org.opencontainers.image.description=ReBAC policy for the PeopleFinder sample
  org.opencontainers.image.licenses=
  org.opencontainers.image.revision=f1d9163a697509990996077a7817a0714ef1b73e
  org.opencontainers.image.source=https://github.com/aserto-templates/policy-peoplefinder-rebac
  org.opencontainers.image.title=policy-peoplefinder-rebac
  org.opencontainers.image.url=https://github.com/aserto-templates/policy-peoplefinder-rebac
  org.opencontainers.image.version=2.3.0
    DOCKER_METADATA_OUTPUT_JSON: {"tags":["ghcr.io/aserto-templates/policy-peoplefinder-rebac:2.3.0","ghcr.io/aserto-templates/policy-peoplefinder-rebac:2.3","ghcr.io/aserto-templates/policy-peoplefinder-rebac:2","ghcr.io/aserto-templates/policy-peoplefinder-rebac:sha-f1d9163","ghcr.io/aserto-templates/policy-peoplefinder-rebac:latest"],"labels":{"org.opencontainers.image.created":"2024-04-24T22:21:24.540Z","org.opencontainers.image.description":"ReBAC policy for the PeopleFinder sample","org.opencontainers.image.licenses":"","org.opencontainers.image.revision":"f1d9163a697509990996077a7817a0714ef1b73e","org.opencontainers.image.source":"https://github.com/aserto-templates/policy-peoplefinder-rebac","org.opencontainers.image.title":"policy-peoplefinder-rebac","org.opencontainers.image.url":"https://github.com/aserto-templates/policy-peoplefinder-rebac","org.opencontainers.image.version":"2.3.0"}}
    DOCKER_METADATA_OUTPUT_BAKE_FILE: /tmp/docker-actions-toolkit-tXQuoU/docker-metadata-action-bake.json
    REPO: aserto-templates/policy-peoplefinder-rebac
    SERVER: ghcr.io
Error: invalid reference: invalid tag
```

I was going to run the command locally when I noticed that we're looping over the image tags instead of uploading them all at once. I modified the call and was able to publish the images successfully from my machine.
Hopefully this works in CI too.